### PR TITLE
test inconsistent with provided .rb file

### DIFF
--- a/spec/hello_spec.rb
+++ b/spec/hello_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "#hello" do 
+describe "#hello_t" do 
   it "takes in an argument of an array and puts out a greeting to each person in the array whose name begins with the letter T" do 
     array = ["Tim", "Tom", "Jim"]
     expect{hello_t(array){|name| puts "Hi, #{name}" if name.start_with?('T') }}.to output("Hi, Tim\nHi, Tom\n").to_stdout


### PR DESCRIPTION
The test raises an error at first blush because the provided method in the .rb file is #hello, but the test is looking for #hello_t. Also the first line of the test says "#hello" and then looks for "#hello_t".
