### PR TITLE
rb file inconsistant with test

### DIFF
--- a/lib/hello.rb
+++ b/lib/hello.rb
@@ -1,4 +1,4 @@
-def hello
+def hello_t
 
 end
 


### PR DESCRIPTION
The test raises an error at first blush because the provided method in the .rb file is #hello, but the test is looking for #hello_t. Also the first line of the test says "#hello" and then looks for "#hello_t".
